### PR TITLE
Potential fix for code scanning alert no. 41: Server-side request forgery

### DIFF
--- a/src/app/api/deployment/status/route.ts
+++ b/src/app/api/deployment/status/route.ts
@@ -12,6 +12,18 @@ export async function GET(request: NextRequest) {
     const deploymentId = searchParams.get('deploymentId');
 
     if (deploymentId) {
+      // Validate deploymentId to prevent SSRF and malformed requests
+      const isValidDeploymentId =
+        typeof deploymentId === 'string' &&
+        /^[a-zA-Z0-9_-]{1,64}$/.test(deploymentId);
+
+      if (!isValidDeploymentId) {
+        return NextResponse.json(
+          { error: 'Invalid deploymentId' },
+          { status: 400 }
+        );
+      }
+
       // Get specific deployment status
       const status = await getDeploymentStatus(deploymentId);
       return NextResponse.json({


### PR DESCRIPTION
Potential fix for [https://github.com/3000Studios/3000studios-next/security/code-scanning/41](https://github.com/3000Studios/3000studios-next/security/code-scanning/41)

In general, to fix this kind of issue you should avoid using raw user input directly in request URLs. Either (1) map user input to known-safe identifiers (allow-list), or (2) strictly validate and sanitize the input so it cannot alter the intended request structure (for example, only allow safe characters and enforce length constraints).

Here, the best non-breaking fix is to validate `deploymentId` as a benign identifier before passing it to `getDeploymentStatus`. Vercel deployment IDs are short strings (typically alphanumeric with dashes), so we can enforce a conservative pattern like `^[a-zA-Z0-9_-]+$` and a reasonable maximum length. If the supplied `deploymentId` fails validation, we should return a 400 response from the API route instead of calling `getDeploymentStatus`. This keeps the existing functionality (clients can still query arbitrary deployment IDs) while ensuring that only well-formed IDs are ever interpolated into the axios URL path. Because the hostname is already constant, we do not need to change `src/lib/services/vercel.ts`; the risk is removed at the source in the route handler.

Concretely:
- In `src/app/api/deployment/status/route.ts`, before using `deploymentId`, add a check that:
  - It is non-empty.
  - It matches a safe regex, e.g. `/^[a-zA-Z0-9_-]{1,64}$/`.
- If invalid, return `NextResponse.json({ error: 'Invalid deploymentId' }, { status: 400 })`.
- No new imports are required; we are using standard language features.

This ensures that CodeQL’s tainted sink only ever receives values that conform to a strict identifier pattern, mitigating SSRF-style URL manipulation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Add strict validation for deploymentId in the deployment status API to prevent server-side request forgery and malformed requests.